### PR TITLE
Add error handling when parsing uptime fails

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -143,24 +143,24 @@ func getServerTechJSON(target, user, pass, path string) ([]byte, error) {
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s/jaws/monitor/%s", target, path), nil)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("failed to create http request: %v", err)
 	}
 	basicAuth := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
 	req.Header.Add("Authorization", "Basic "+basicAuth)
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("failed to perform http request: %v", err)
 	}
 
 	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("incorrect status code receiveved from device: %d", resp.StatusCode)
+		return nil, fmt.Errorf("incorrect status code received from device: %d", resp.StatusCode)
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("failed to read body of request from device: %v", err)
 	}
 
 	return body, nil

--- a/collector/system.go
+++ b/collector/system.go
@@ -75,6 +75,11 @@ func processSystemStats(ch chan<- prometheus.Metric, jsonSystemSum []byte) error
 		return fmt.Errorf("could not compile uptime regex: %v", err)
 	}
 	reUptime := r.FindStringSubmatch(data.Uptime)
+
+	if len(reUptime) < 4 {
+		return fmt.Errorf("uptime data was not in expected format: %v", data.Uptime)
+	}
+
 	uptimeDays, err := strconv.Atoi(reUptime[1])
 	if err != nil {
 		return fmt.Errorf("could not convert uptime day to int: %v", err)


### PR DESCRIPTION
Servertech exporter can sometimes crash ungracefully with an index out of bounds error when the regex parsing "uptime" does not get the expected string. This MR adds some graceful error handling.

```
panic: runtime error: index out of range [1] with length 0
goroutine 785 [running]:github.com/tynany/servertech_exporter/collector.processSystemStats(0xc000c38ea0, 0xc000371600, 0x1c3, 0x200, 0xc0004b3000, 0x15)
/go/src/github.com/tynany/servertech_exporter/collector/system.go:78 +0xb9fgithub.com/tynany/servertech_exporter/collector.(*SystemCollector).Get(0xe76858, 0xc000c38ea0, 0xc0003c87fd, 0xa, 0xc0003c880d, 0x7, 0xc0004b3000, 0x15, 0x10000c000513540, 0x0, ...)
/go/src/github.com/tynany/servertech_exporter/collector/system.go:48 +0x174github.com/tynany/servertech_exporter/collector.(*Exporter).runCollector(0xc000d08a00, 0xc000c38ea0, 0x9c9e78, 0x6, 0xa838c0, 0xe76858, 0xc000605d80)
/go/src/github.com/tynany/servertech_exporter/collector/collector.go:100 +0xf6created by github.com/tynany/servertech_exporter/collector.(*Exporter).Collect
/go/src/github.com/tynany/servertech_exporter/collector/collector.go:91 +0x21b
```